### PR TITLE
TTRSUPP-62: update Faraday dependency from ~1 to ~2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     crmp_client (0.1.0)
-      faraday (~> 2.0)
+      faraday (~> 2)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     crmp_client (0.1.0)
-      faraday (~> 1.0)
+      faraday (~> 2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -20,16 +20,14 @@ GEM
     docile (1.3.5)
     faker (2.15.1)
       i18n (>= 1.6, < 2)
-    faraday (1.3.0)
-      faraday-net_http (~> 1.0)
-      multipart-post (>= 1.2, < 3)
-      ruby2_keywords
-    faraday-net_http (1.0.1)
+    faraday (2.7.10)
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (3.0.2)
     hashdiff (1.0.1)
     i18n (1.8.7)
       concurrent-ruby (~> 1.0)
     method_source (1.0.0)
-    multipart-post (2.1.1)
     parallel (1.20.1)
     parser (3.0.0.0)
       ast (~> 2.4.1)
@@ -71,7 +69,7 @@ GEM
       rubocop (~> 1.0)
       rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.11.0)
-    ruby2_keywords (0.0.4)
+    ruby2_keywords (0.0.5)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -86,6 +84,7 @@ GEM
     yard (0.9.26)
 
 PLATFORMS
+  ruby
   x86_64-linux
 
 DEPENDENCIES

--- a/crmp_client.gemspec
+++ b/crmp_client.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'faraday', '~> 1.0'
+  spec.add_dependency 'faraday', '~> 2.0'
 
   spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'codecov', '>= 0.4'

--- a/crmp_client.gemspec
+++ b/crmp_client.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'faraday', '~> 2.0'
+  spec.add_dependency 'faraday', '~> 2'
 
   spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'codecov', '>= 0.4'


### PR DESCRIPTION
In order to bump up facebookbusiness in ID to v.16, faraday in crmp_client must also be bumped up from 1.0 to 2.0

### Faraday breaking changes from v1 -> v2
https://github.com/lostisland/awesome-faraday
https://github.com/lostisland/faraday/blob/main/UPGRADING.md
They've removed a lot of the adapters out in to separate gems, so that they're not bundled in the farsday core gem. Luckily the only adapter they kept in the core Gem is the only one we need `https://github.com/lostisland/faraday-net_http` so this breaking change won't affect us
